### PR TITLE
Add support for inline filters

### DIFF
--- a/index.js
+++ b/index.js
@@ -506,9 +506,33 @@ Parser.prototype = {
     var attrs = this.accept('attrs');
     var block;
 
-    block = this.parseTextBlock() || {type: 'Block', nodes: [], line: tok.line, filename: this.filename};
+    if (this.peek().type === 'text') {
+      var textToken = this.advance();
+      block = {
+        type: 'Block',
+        nodes: [
+          {
+            type: 'Text',
+            val: textToken.val,
+            line: textToken.line,
+            filename: this.filename
+          }
+        ],
+        line: textToken.line,
+        filename: this.filename
+      };
+    } else {
+      block = this.parseTextBlock() || {type: 'Block', nodes: [], line: tok.line, filename: this.filename};
+    }
 
-    return {type: 'Filter', name: tok.val, block: block, attrs: attrs ? attrs.attrs : [], line: tok.line, filename: this.filename};
+    return {
+      type: 'Filter',
+      name: tok.val,
+      block: block,
+      attrs: attrs ? attrs.attrs : [],
+      line: tok.line,
+      filename: this.filename
+    };
   },
 
   /**

--- a/test/cases/filters.inline.expected.json
+++ b/test/cases/filters.inline.expected.json
@@ -1,0 +1,54 @@
+{
+  "type": "Block",
+  "nodes": [
+    {
+      "type": "Tag",
+      "name": "p",
+      "selfClosing": false,
+      "block": {
+        "type": "Block",
+        "nodes": [
+          {
+            "type": "Text",
+            "val": "before ",
+            "line": 1,
+            "filename": "filters.inline.tokens.json"
+          },
+          {
+            "type": "Filter",
+            "name": "cdata",
+            "block": {
+              "type": "Block",
+              "nodes": [
+                {
+                  "type": "Text",
+                  "val": "inside",
+                  "line": 1,
+                  "filename": "filters.inline.tokens.json"
+                }
+              ],
+              "line": 1,
+              "filename": "filters.inline.tokens.json"
+            },
+            "attrs": [],
+            "line": 1,
+            "filename": "filters.inline.tokens.json"
+          },
+          {
+            "type": "Text",
+            "val": " after",
+            "line": 1,
+            "filename": "filters.inline.tokens.json"
+          }
+        ]
+      },
+      "attrs": [],
+      "attributeBlocks": [],
+      "isInline": false,
+      "line": 1,
+      "filename": "filters.inline.tokens.json"
+    }
+  ],
+  "line": 0,
+  "filename": "filters.inline.tokens.json"
+}

--- a/test/cases/filters.inline.tokens.json
+++ b/test/cases/filters.inline.tokens.json
@@ -1,0 +1,8 @@
+{"type":"tag","line":1,"val":"p","selfClosing":false}
+{"type":"text","line":1,"val":"before "}
+{"type":"start-jade-interpolation","line":1}
+{"type":"filter","line":1,"val":"cdata"}
+{"type":"text","line":1,"val":"inside"}
+{"type":"end-jade-interpolation","line":1}
+{"type":"text","line":1,"val":" after"}
+{"type":"eos","line":1}


### PR DESCRIPTION
See jadejs/jade#1886.  Adds support for:

```jade
p before #[:cdata inside] after
```

which should render to

```html
<p>before <![CDATA[inside]]> after</p>
```