### PR TITLE
Fixed parser errors connected with unbuffered comments...

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ Parser.prototype = {
     var tokens = []
 
     while ('eos' != this.peek().type) {
-      if(this.peek().type == 'comment'){
+      if('comment' == this.peek().type){
         var comment = this.parseComment()
         if(comment.buffer){
           tokens.push(comment)

--- a/index.js
+++ b/index.js
@@ -85,6 +85,39 @@ Parser.prototype = {
   },
 
   /**
+   * Pre-parse the token stream, drop everything we will not be using
+   * to generate code.
+   *
+   * This will pre-collect comments and drop unbuffered comments, 
+   * considering that the comments as a "token" are context-free this 
+   * should have no side-effects.
+   *
+   * @return {Parser} 
+   * @api public
+   */
+
+  preParse: function(){
+    var tokens = []
+
+    while ('eos' != this.peek().type) {
+      if(this.peek().type == 'comment'){
+        var comment = this.parseComment()
+        if(comment.buffer){
+          tokens.push(comment)
+        }
+      } else {
+        tokens.push(this.advance())
+      }
+    }
+    // push back the eos...
+    tokens.push(this.advance())
+
+    this.tokens = new TokenStream(tokens)
+
+    return this
+  },
+
+  /**
    * Parse input returning a string of js for evaluation.
    *
    * @return {String}
@@ -92,6 +125,9 @@ Parser.prototype = {
    */
 
   parse: function(){
+
+    this.preParse()
+
     var block ={type: 'Block', nodes: [], line: 0, filename: this.filename};
 
     while ('eos' != this.peek().type) {
@@ -100,7 +136,7 @@ Parser.prototype = {
       } else if ('text-html' == this.peek().type) {
         block.nodes = block.nodes.concat(this.parseTextHtml());
       } else {
-        var next = this.peek();
+        //var next = this.peek();
         var expr = this.parseExpr();
         block.nodes.push(expr);
       }
@@ -173,6 +209,11 @@ Parser.prototype = {
         return this.parseDoctype();
       case 'filter':
         return this.parseFilter();
+      // already parsed comments...
+      case 'Comment':
+      case 'BlockComment':
+        return this.advance();
+      // XXX do we still need this???
       case 'comment':
         return this.parseComment();
       case 'text':

--- a/test/cases/block-code.expected.json
+++ b/test/cases/block-code.expected.json
@@ -11,8 +11,8 @@
     },
     {
       "type": "Comment",
-      "val": " Without a block, the element is accepted and no code is generated",
-      "buffer": false,
+      "val": " Without a block, the element is accepted",
+      "buffer": true,
       "line": 4,
       "filename": "block-code.tokens.json"
     },

--- a/test/cases/block-code.tokens.json
+++ b/test/cases/block-code.tokens.json
@@ -5,6 +5,7 @@
 {"type":"text","line":3,"val":"        \"cuatro\", \"cinco\", \"seis\"];"}
 {"type":"end-pipeless-text","line":3}
 {"type":"newline","line":4}
+{"type":"comment","line":4,"val":" Without a block, the element is accepted","buffer":true}
 {"type":"comment","line":4,"val":" Without a block, the element is accepted and no code is generated","buffer":false}
 {"type":"newline","line":5}
 {"type":"blockcode","line":5}

--- a/test/cases/blocks-in-if.expected.json
+++ b/test/cases/blocks-in-if.expected.json
@@ -2,13 +2,6 @@
   "type": "Block",
   "nodes": [
     {
-      "type": "Comment",
-      "val": " see https://github.com/jadejs/jade/issues/1589",
-      "buffer": false,
-      "line": 1,
-      "filename": "blocks-in-if.tokens.json"
-    },
-    {
       "type": "Text",
       "val": "",
       "line": 2,
@@ -32,13 +25,6 @@
       "block": {
         "type": "Block",
         "nodes": [
-          {
-            "type": "Comment",
-            "val": " return only contents if ajax requests",
-            "buffer": false,
-            "line": 6,
-            "filename": "blocks-in-if.tokens.json"
-          },
           {
             "type": "NamedBlock",
             "nodes": [
@@ -85,13 +71,6 @@
       "block": {
         "type": "Block",
         "nodes": [
-          {
-            "type": "Comment",
-            "val": " return all html",
-            "buffer": false,
-            "line": 11,
-            "filename": "blocks-in-if.tokens.json"
-          },
           {
             "type": "Doctype",
             "val": "html",

--- a/test/cases/code.conditionals.expected.json
+++ b/test/cases/code.conditionals.expected.json
@@ -384,7 +384,7 @@
     {
       "type": "Comment",
       "val": " allow empty blocks",
-      "buffer": false,
+      "buffer": true,
       "line": 29,
       "filename": "code.conditionals.tokens.json"
     },

--- a/test/cases/code.conditionals.tokens.json
+++ b/test/cases/code.conditionals.tokens.json
@@ -55,7 +55,7 @@
 {"type":"text","line":27,"val":"yay"}
 {"type":"outdent","line":29}
 {"type":"outdent","line":29}
-{"type":"comment","line":29,"val":" allow empty blocks","buffer":false}
+{"type":"comment","line":29,"val":" allow empty blocks","buffer":true}
 {"type":"newline","line":30}
 {"type":"code","line":30,"val":"if ( false)","isElse":false,"isIf":true,"requiresBlock":true}
 {"type":"newline","line":31}

--- a/test/cases/comments.expected.json
+++ b/test/cases/comments.expected.json
@@ -201,53 +201,6 @@
       "filename": "comments.tokens.json"
     },
     {
-      "type": "BlockComment",
-      "val": "if IE lt 9",
-      "block": {
-        "type": "Block",
-        "nodes": [
-          {
-            "type": "Text",
-            "val": "// inline",
-            "line": 23
-          },
-          {
-            "type": "Text",
-            "val": "\n",
-            "line": 24
-          },
-          {
-            "type": "Text",
-            "val": "script(src='/lame.js')",
-            "line": 24
-          },
-          {
-            "type": "Text",
-            "val": "\n",
-            "line": 25
-          },
-          {
-            "type": "Text",
-            "val": "// end-inline",
-            "line": 25
-          },
-          {
-            "type": "Text",
-            "val": "\n",
-            "line": 26
-          },
-          {
-            "type": "Text",
-            "val": "",
-            "line": 26
-          }
-        ]
-      },
-      "buffer": true,
-      "line": 22,
-      "filename": "comments.tokens.json"
-    },
-    {
       "type": "Tag",
       "name": "p",
       "selfClosing": false,

--- a/test/cases/comments.source.expected.json
+++ b/test/cases/comments.source.expected.json
@@ -24,14 +24,14 @@
           }
         ]
       },
-      "buffer": false,
+      "buffer": true,
       "line": 1,
       "filename": "comments.source.tokens.json"
     },
     {
       "type": "Comment",
       "val": " test/cases/comments.source.jade",
-      "buffer": false,
+      "buffer": true,
       "line": 4,
       "filename": "comments.source.tokens.json"
     },
@@ -74,7 +74,7 @@
           }
         ]
       },
-      "buffer": false,
+      "buffer": true,
       "line": 6,
       "filename": "comments.source.tokens.json"
     }

--- a/test/cases/comments.source.tokens.json
+++ b/test/cases/comments.source.tokens.json
@@ -1,14 +1,14 @@
-{"type":"comment","line":1,"val":"","buffer":false}
+{"type":"comment","line":1,"val":"","buffer":true}
 {"type":"start-pipeless-text","line":1}
 {"type":"text","line":2,"val":"s/s."}
 {"type":"newline","line":3}
 {"type":"text","line":3,"val":""}
 {"type":"end-pipeless-text","line":3}
 {"type":"newline","line":4}
-{"type":"comment","line":4,"val":" test/cases/comments.source.jade","buffer":false}
+{"type":"comment","line":4,"val":" test/cases/comments.source.jade","buffer":true}
 {"type":"text","line":5,"val":""}
 {"type":"newline","line":6}
-{"type":"comment","line":6,"val":"","buffer":false}
+{"type":"comment","line":6,"val":"","buffer":true}
 {"type":"start-pipeless-text","line":6}
 {"type":"text","line":7,"val":"test/cases/comments.source.jade"}
 {"type":"newline","line":8}

--- a/test/cases/comments.tokens.json
+++ b/test/cases/comments.tokens.json
@@ -42,7 +42,7 @@
 {"type":"text","line":21,"val":""}
 {"type":"end-pipeless-text","line":21}
 {"type":"newline","line":22}
-{"type":"comment","line":22,"val":"if IE lt 9","buffer":true}
+{"type":"comment","line":22,"val":"if IE lt 9","buffer":false}
 {"type":"start-pipeless-text","line":22}
 {"type":"text","line":23,"val":"// inline"}
 {"type":"newline","line":24}

--- a/test/cases/mixin-via-include.expected.json
+++ b/test/cases/mixin-via-include.expected.json
@@ -4,7 +4,7 @@
     {
       "type": "Comment",
       "val": " regression test for https://github.com/jadejs/jade/issues/1435",
-      "buffer": false,
+      "buffer": true,
       "line": 1,
       "filename": "mixin-via-include.tokens.json"
     },

--- a/test/cases/mixin-via-include.tokens.json
+++ b/test/cases/mixin-via-include.tokens.json
@@ -1,4 +1,4 @@
-{"type":"comment","line":1,"val":" regression test for https://github.com/jadejs/jade/issues/1435","buffer":false}
+{"type":"comment","line":1,"val":" regression test for https://github.com/jadejs/jade/issues/1435","buffer":true}
 {"type":"text","line":2,"val":""}
 {"type":"newline","line":3}
 {"type":"include","line":3,"val":"../fixtures/mixin-include.jade"}

--- a/test/cases/mixin.attrs.expected.json
+++ b/test/cases/mixin.attrs.expected.json
@@ -632,7 +632,7 @@
     {
       "type": "Comment",
       "val": " Regression test for #1424",
-      "buffer": false,
+      "buffer": true,
       "line": 38,
       "filename": "mixin.attrs.tokens.json"
     },

--- a/test/cases/mixin.attrs.tokens.json
+++ b/test/cases/mixin.attrs.tokens.json
@@ -96,7 +96,7 @@
 {"type":"attrs","line":36,"attrs":[{"name":"attr3","val":"'baz'","escaped":true},{"name":"data-foo","val":"val","escaped":true},{"name":"data-bar","val":"val","escaped":false},{"name":"class","val":"classes","escaped":true}]}
 {"type":"class","line":36,"val":"thunk"}
 {"type":"newline","line":38}
-{"type":"comment","line":38,"val":" Regression test for #1424","buffer":false}
+{"type":"comment","line":38,"val":" Regression test for #1424","buffer":true}
 {"type":"newline","line":39}
 {"type":"mixin","line":39,"val":"work_filmstrip_item","args":"work"}
 {"type":"indent","line":40,"val":2}

--- a/test/cases/tags.self-closing.expected.json
+++ b/test/cases/tags.self-closing.expected.json
@@ -127,7 +127,7 @@
           {
             "type": "Comment",
             "val": " can have a single space after them",
-            "buffer": false,
+            "buffer": true,
             "line": 9,
             "filename": "tags.self-closing.tokens.json"
           },
@@ -155,7 +155,7 @@
           {
             "type": "Comment",
             "val": " can have lots of white space after them",
-            "buffer": false,
+            "buffer": true,
             "line": 11,
             "filename": "tags.self-closing.tokens.json"
           },

--- a/test/cases/tags.self-closing.tokens.json
+++ b/test/cases/tags.self-closing.tokens.json
@@ -18,12 +18,12 @@
 {"type":"attrs","line":8,"attrs":[{"name":"bar","val":"'baz'","escaped":true}]}
 {"type":"text","line":8,"val":"/"}
 {"type":"newline","line":9}
-{"type":"comment","line":9,"val":" can have a single space after them","buffer":false}
+{"type":"comment","line":9,"val":" can have a single space after them","buffer":true}
 {"type":"newline","line":10}
 {"type":"tag","line":10,"val":"img","selfClosing":false}
 {"type":"text","line":10,"val":" "}
 {"type":"newline","line":11}
-{"type":"comment","line":11,"val":" can have lots of white space after them","buffer":false}
+{"type":"comment","line":11,"val":" can have lots of white space after them","buffer":true}
 {"type":"newline","line":12}
 {"type":"tag","line":12,"val":"img","selfClosing":false}
 {"type":"text","line":12,"val":"   "}


### PR DESCRIPTION
This patch adds a pre-parse phase, filtering out everything that is not to be used in code generation (namely unbuffered comments) from the token stream and pre-parsing comments as a side effect.

The changes are minimal and should be self-explanatory.

IMO, this is the simplest way solve this issue as it reuses existing code with almost no modification and no special cases that would complicate the parsing logic.

The only thing I'm not too happy with is the set of tests, they seemed to be auto-generated, but the generator was not in this repo, and adding tests on this level by hand seemed a bit odd, so I simply fixed up anything that was touching the changed token stream / AST.
In almost all the test-cases the comments were unbuffered, and thus were not part of the parsed AST failing the test, so in part of the cases they needed to be removed them from the *.expected.json completely and in others the buffer token attr was set to true in both the *.tokens.json and the corresponding *.expected.json, this effectively covers testing of all the changes made by the patch, though not in one single place.

And as a bonus, this pre-parse phase can be used in the future to implement Common-Lisp style macros :)

Fixes https://github.com/jadejs/jade/issues/1954, https://github.com/jadejs/jade/issues/1944