### PR TITLE
Error out on deprecated mixin call syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -827,7 +827,6 @@ Parser.prototype = {
     var name = tok.val;
     var args = tok.args;
 
-    // definition
     if ('indent' == this.peek().type) {
       this.inMixin++;
       var mixin = {
@@ -841,21 +840,8 @@ Parser.prototype = {
       };
       this.inMixin--;
       return mixin;
-    // call
     } else {
-      console.warn('Deprecated method of calling mixins, use `+name` syntax (' +
-                   this.filename + ' line ' + tok.line + ')');
-      return {
-        type: 'Mixin',
-        name: name,
-        args: args,
-        block: this.emptyBlock(tok.line),
-        call: true,
-        attrs: [],
-        attributeBlocks: [],
-        line: tok.line,
-        filename: this.filename
-      };
+      this.error('MIXIN_WITHOUT_BODY', 'Mixin ' + name + ' declared without body', tok);
     }
   },
 

--- a/test/cases/filters.markdown.expected.json
+++ b/test/cases/filters.markdown.expected.json
@@ -17,7 +17,7 @@
               "nodes": [
                 {
                   "type": "Filter",
-                  "name": "marked",
+                  "name": "markdown-it",
                   "block": {
                     "type": "Block",
                     "nodes": [

--- a/test/cases/filters.markdown.tokens.json
+++ b/test/cases/filters.markdown.tokens.json
@@ -2,8 +2,8 @@
 {"type":"indent","line":2,"col":1,"val":2}
 {"type":"tag","line":2,"col":3,"val":"body"}
 {"type":"indent","line":3,"col":1,"val":4}
-{"type":"filter","line":3,"col":5,"val":"marked"}
-{"type":"start-pipeless-text","line":3,"col":12}
+{"type":"filter","line":3,"col":5,"val":"markdown-it"}
+{"type":"start-pipeless-text","line":3,"col":17}
 {"type":"text","line":4,"col":7,"val":"This is _some_ awesome **markdown**"}
 {"type":"newline","line":5,"col":1}
 {"type":"text","line":5,"col":7,"val":"whoop."}

--- a/test/cases/include-filter.expected.json
+++ b/test/cases/include-filter.expected.json
@@ -28,7 +28,7 @@
                   "filters": [
                     {
                       "type": "IncludeFilter",
-                      "name": "marked",
+                      "name": "markdown-it",
                       "attrs": [],
                       "line": 3,
                       "filename": "include-filter.tokens.json"

--- a/test/cases/include-filter.tokens.json
+++ b/test/cases/include-filter.tokens.json
@@ -3,8 +3,8 @@
 {"type":"tag","line":2,"col":3,"val":"body"}
 {"type":"indent","line":3,"col":1,"val":4}
 {"type":"include","line":3,"col":5}
-{"type":"filter","line":3,"col":12,"val":"marked"}
-{"type":"path","line":3,"col":20,"val":"some.md"}
+{"type":"filter","line":3,"col":12,"val":"markdown-it"}
+{"type":"path","line":3,"col":25,"val":"some.md"}
 {"type":"newline","line":4,"col":1}
 {"type":"tag","line":4,"col":5,"val":"script"}
 {"type":"indent","line":5,"col":1,"val":6}

--- a/test/cases/mixin-hoist.expected.json
+++ b/test/cases/mixin-hoist.expected.json
@@ -60,12 +60,7 @@
                   "type": "Mixin",
                   "name": "foo",
                   "args": null,
-                  "block": {
-                    "type": "Block",
-                    "nodes": [],
-                    "line": 7,
-                    "filename": "mixin-hoist.tokens.json"
-                  },
+                  "block": null,
                   "call": true,
                   "attrs": [],
                   "attributeBlocks": [],

--- a/test/cases/mixin-hoist.tokens.json
+++ b/test/cases/mixin-hoist.tokens.json
@@ -8,7 +8,7 @@
 {"type":"indent","line":6,"col":1,"val":2}
 {"type":"tag","line":6,"col":3,"val":"body"}
 {"type":"indent","line":7,"col":1,"val":4}
-{"type":"mixin","line":7,"col":5,"val":"foo","args":null}
+{"type":"call","line":7,"col":5,"val":"foo","args":null}
 {"type":"outdent","line":8,"col":3}
 {"type":"outdent","line":8,"col":1}
 {"type":"eos","line":8,"col":1}

--- a/test/cases/mixin.attrs.expected.json
+++ b/test/cases/mixin.attrs.expected.json
@@ -738,6 +738,125 @@
     },
     {
       "type": "Mixin",
+      "name": "my-mixin",
+      "args": "arg1, arg2, arg3, arg4",
+      "block": {
+        "type": "Block",
+        "nodes": [
+          {
+            "type": "Tag",
+            "name": "p",
+            "selfClosing": false,
+            "block": {
+              "type": "Block",
+              "nodes": [
+                {
+                  "type": "Code",
+                  "val": "arg1",
+                  "buffer": true,
+                  "mustEscape": true,
+                  "isInline": true,
+                  "line": 44,
+                  "filename": "mixin.attrs.tokens.json"
+                }
+              ],
+              "line": 44,
+              "filename": "mixin.attrs.tokens.json"
+            },
+            "attrs": [],
+            "attributeBlocks": [],
+            "isInline": false,
+            "line": 44,
+            "filename": "mixin.attrs.tokens.json"
+          },
+          {
+            "type": "Tag",
+            "name": "p",
+            "selfClosing": false,
+            "block": {
+              "type": "Block",
+              "nodes": [
+                {
+                  "type": "Code",
+                  "val": "arg2",
+                  "buffer": true,
+                  "mustEscape": true,
+                  "isInline": true,
+                  "line": 45,
+                  "filename": "mixin.attrs.tokens.json"
+                }
+              ],
+              "line": 45,
+              "filename": "mixin.attrs.tokens.json"
+            },
+            "attrs": [],
+            "attributeBlocks": [],
+            "isInline": false,
+            "line": 45,
+            "filename": "mixin.attrs.tokens.json"
+          },
+          {
+            "type": "Tag",
+            "name": "p",
+            "selfClosing": false,
+            "block": {
+              "type": "Block",
+              "nodes": [
+                {
+                  "type": "Code",
+                  "val": "arg3",
+                  "buffer": true,
+                  "mustEscape": true,
+                  "isInline": true,
+                  "line": 46,
+                  "filename": "mixin.attrs.tokens.json"
+                }
+              ],
+              "line": 46,
+              "filename": "mixin.attrs.tokens.json"
+            },
+            "attrs": [],
+            "attributeBlocks": [],
+            "isInline": false,
+            "line": 46,
+            "filename": "mixin.attrs.tokens.json"
+          },
+          {
+            "type": "Tag",
+            "name": "p",
+            "selfClosing": false,
+            "block": {
+              "type": "Block",
+              "nodes": [
+                {
+                  "type": "Code",
+                  "val": "arg4",
+                  "buffer": true,
+                  "mustEscape": true,
+                  "isInline": true,
+                  "line": 47,
+                  "filename": "mixin.attrs.tokens.json"
+                }
+              ],
+              "line": 47,
+              "filename": "mixin.attrs.tokens.json"
+            },
+            "attrs": [],
+            "attributeBlocks": [],
+            "isInline": false,
+            "line": 47,
+            "filename": "mixin.attrs.tokens.json"
+          }
+        ],
+        "line": 44,
+        "filename": "mixin.attrs.tokens.json"
+      },
+      "call": false,
+      "line": 43,
+      "filename": "mixin.attrs.tokens.json"
+    },
+    {
+      "type": "Mixin",
       "name": "foo",
       "args": null,
       "block": null,
@@ -755,18 +874,18 @@
         }
       ],
       "attributeBlocks": [],
-      "line": 43,
+      "line": 49,
       "filename": "mixin.attrs.tokens.json"
     },
     {
       "type": "Mixin",
       "name": "my-mixin",
-      "args": "\narg1,\n      arg2,\n  arg3,\n      arg4\n",
+      "args": "\n'1',\n      '2',\n  '3',\n      '4'\n",
       "block": null,
       "call": true,
       "attrs": [],
       "attributeBlocks": [],
-      "line": 48,
+      "line": 54,
       "filename": "mixin.attrs.tokens.json"
     }
   ],

--- a/test/cases/mixin.attrs.tokens.json
+++ b/test/cases/mixin.attrs.tokens.json
@@ -136,11 +136,26 @@
 {"type":"attribute","line":41,"col":56,"name":"data-creator-name","val":"'name'","mustEscape":true}
 {"type":"end-attributes","line":41,"col":82}
 {"type":"newline","line":43,"col":1}
-{"type":"call","line":43,"col":1,"val":"foo","args":null}
-{"type":"start-attributes","line":43,"col":5}
-{"type":"attribute","line":44,"col":3,"name":"attr3","val":"\"qux\"","mustEscape":true}
-{"type":"attribute","line":45,"col":3,"name":"class","val":"\"baz\"","mustEscape":true}
-{"type":"end-attributes","line":46,"col":1}
-{"type":"newline","line":48,"col":1}
-{"type":"call","line":48,"col":1,"val":"my-mixin","args":"\narg1,\n      arg2,\n  arg3,\n      arg4\n"}
-{"type":"eos","line":53,"col":2}
+{"type":"mixin","line":43,"col":1,"val":"my-mixin","args":"arg1, arg2, arg3, arg4"}
+{"type":"indent","line":44,"col":1,"val":2}
+{"type":"tag","line":44,"col":3,"val":"p"}
+{"type":"code","line":44,"col":4,"val":"arg1","mustEscape":true,"buffer":true}
+{"type":"newline","line":45,"col":1}
+{"type":"tag","line":45,"col":3,"val":"p"}
+{"type":"code","line":45,"col":4,"val":"arg2","mustEscape":true,"buffer":true}
+{"type":"newline","line":46,"col":1}
+{"type":"tag","line":46,"col":3,"val":"p"}
+{"type":"code","line":46,"col":4,"val":"arg3","mustEscape":true,"buffer":true}
+{"type":"newline","line":47,"col":1}
+{"type":"tag","line":47,"col":3,"val":"p"}
+{"type":"code","line":47,"col":4,"val":"arg4","mustEscape":true,"buffer":true}
+{"type":"outdent","line":49,"col":1}
+{"type":"call","line":49,"col":1,"val":"foo","args":null}
+{"type":"start-attributes","line":49,"col":5}
+{"type":"attribute","line":50,"col":3,"name":"attr3","val":"\"qux\"","mustEscape":true}
+{"type":"attribute","line":51,"col":3,"name":"class","val":"\"baz\"","mustEscape":true}
+{"type":"end-attributes","line":52,"col":1}
+{"type":"newline","line":54,"col":1}
+{"type":"call","line":54,"col":1,"val":"my-mixin","args":"\n'1',\n      '2',\n  '3',\n      '4'\n"}
+{"type":"newline","line":60,"col":1}
+{"type":"eos","line":60,"col":1}

--- a/test/cases/mixins.expected.json
+++ b/test/cases/mixins.expected.json
@@ -384,13 +384,8 @@
           {
             "type": "Mixin",
             "name": "list",
-            "args": null,
-            "block": {
-              "type": "Block",
-              "nodes": [],
-              "line": 25,
-              "filename": "mixins.tokens.json"
-            },
+            "args": "",
+            "block": null,
             "call": true,
             "attrs": [],
             "attributeBlocks": [],
@@ -406,17 +401,6 @@
             "attrs": [],
             "attributeBlocks": [],
             "line": 26,
-            "filename": "mixins.tokens.json"
-          },
-          {
-            "type": "Mixin",
-            "name": "list",
-            "args": "",
-            "block": null,
-            "call": true,
-            "attrs": [],
-            "attributeBlocks": [],
-            "line": 27,
             "filename": "mixins.tokens.json"
           }
         ],
@@ -449,11 +433,11 @@
                   "buffer": true,
                   "mustEscape": true,
                   "isInline": true,
-                  "line": 30,
+                  "line": 29,
                   "filename": "mixins.tokens.json"
                 }
               ],
-              "line": 30,
+              "line": 29,
               "filename": "mixins.tokens.json"
             },
             "attrs": [
@@ -465,15 +449,15 @@
             ],
             "attributeBlocks": [],
             "isInline": false,
-            "line": 30,
+            "line": 29,
             "filename": "mixins.tokens.json"
           }
         ],
-        "line": 30,
+        "line": 29,
         "filename": "mixins.tokens.json"
       },
       "call": false,
-      "line": 29,
+      "line": 28,
       "filename": "mixins.tokens.json"
     },
     {
@@ -482,7 +466,7 @@
       "buffer": false,
       "mustEscape": false,
       "isInline": false,
-      "line": 32,
+      "line": 31,
       "filename": "mixins.tokens.json"
     },
     {
@@ -493,7 +477,7 @@
       "call": true,
       "attrs": [],
       "attributeBlocks": [],
-      "line": 33,
+      "line": 32,
       "filename": "mixins.tokens.json"
     }
   ],

--- a/test/cases/mixins.tokens.json
+++ b/test/cases/mixins.tokens.json
@@ -48,20 +48,18 @@
 {"type":"outdent","line":24,"col":1}
 {"type":"tag","line":24,"col":1,"val":"body"}
 {"type":"indent","line":25,"col":1,"val":2}
-{"type":"mixin","line":25,"col":3,"val":"list","args":null}
+{"type":"call","line":25,"col":3,"val":"list","args":""}
 {"type":"newline","line":26,"col":1}
 {"type":"call","line":26,"col":3,"val":"list","args":""}
-{"type":"newline","line":27,"col":1}
-{"type":"call","line":27,"col":3,"val":"list","args":""}
-{"type":"outdent","line":29,"col":1}
-{"type":"mixin","line":29,"col":1,"val":"foobar","args":"str"}
-{"type":"indent","line":30,"col":1,"val":2}
-{"type":"tag","line":30,"col":3,"val":"div"}
-{"type":"id","line":30,"col":6,"val":"interpolation"}
-{"type":"code","line":30,"col":20,"val":"str + 'interpolated'","mustEscape":true,"buffer":true}
-{"type":"outdent","line":32,"col":1}
-{"type":"code","line":32,"col":1,"val":"var suffix = \"bar\"","mustEscape":false,"buffer":false}
+{"type":"outdent","line":28,"col":1}
+{"type":"mixin","line":28,"col":1,"val":"foobar","args":"str"}
+{"type":"indent","line":29,"col":1,"val":2}
+{"type":"tag","line":29,"col":3,"val":"div"}
+{"type":"id","line":29,"col":6,"val":"interpolation"}
+{"type":"code","line":29,"col":20,"val":"str + 'interpolated'","mustEscape":true,"buffer":true}
+{"type":"outdent","line":31,"col":1}
+{"type":"code","line":31,"col":1,"val":"var suffix = \"bar\"","mustEscape":false,"buffer":false}
+{"type":"newline","line":32,"col":1}
+{"type":"call","line":32,"col":1,"val":"#{'foo' + suffix}","args":"'This is '"}
 {"type":"newline","line":33,"col":1}
-{"type":"call","line":33,"col":1,"val":"#{'foo' + suffix}","args":"'This is '"}
-{"type":"newline","line":34,"col":1}
-{"type":"eos","line":34,"col":1}
+{"type":"eos","line":33,"col":1}

--- a/test/cases/pipeless-filters.expected.json
+++ b/test/cases/pipeless-filters.expected.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "type": "Filter",
-      "name": "marked",
+      "name": "markdown-it",
       "block": {
         "type": "Block",
         "nodes": [

--- a/test/cases/pipeless-filters.tokens.json
+++ b/test/cases/pipeless-filters.tokens.json
@@ -1,5 +1,5 @@
-{"type":"filter","line":1,"col":1,"val":"marked"}
-{"type":"start-pipeless-text","line":1,"col":8}
+{"type":"filter","line":1,"col":1,"val":"markdown-it"}
+{"type":"start-pipeless-text","line":1,"col":13}
 {"type":"text","line":2,"col":3,"val":"    code sample"}
 {"type":"newline","line":3,"col":1}
 {"type":"text","line":3,"col":3,"val":""}

--- a/test/cases/tags.self-closing.expected.json
+++ b/test/cases/tags.self-closing.expected.json
@@ -285,6 +285,22 @@
             "isInline": true,
             "line": 16,
             "filename": "tags.self-closing.tokens.json"
+          },
+          {
+            "type": "InterpolatedTag",
+            "expr": "\n    'foo'\n  ",
+            "selfClosing": true,
+            "block": {
+              "type": "Block",
+              "nodes": [],
+              "line": 17,
+              "filename": "tags.self-closing.tokens.json"
+            },
+            "attrs": [],
+            "attributeBlocks": [],
+            "isInline": false,
+            "line": 17,
+            "filename": "tags.self-closing.tokens.json"
           }
         ],
         "line": 2,

--- a/test/cases/tags.self-closing.tokens.json
+++ b/test/cases/tags.self-closing.tokens.json
@@ -53,5 +53,8 @@
 {"type":"newline","line":16,"col":1}
 {"type":"tag","line":16,"col":3,"val":"img"}
 {"type":"text","line":16,"col":7,"val":"   "}
-{"type":"outdent","line":17,"col":1}
-{"type":"eos","line":17,"col":1}
+{"type":"newline","line":17,"col":1}
+{"type":"interpolation","line":17,"col":3,"val":"\n    'foo'\n  "}
+{"type":"slash","line":19,"col":4}
+{"type":"outdent","line":20,"col":1}
+{"type":"eos","line":20,"col":1}


### PR DESCRIPTION
I could simply remove the entire conditional, but that would lead to difficult-to-debug issues if the user was not aware of the deprecation warning.